### PR TITLE
ref #7: footer-navigation styling

### DIFF
--- a/Resources/public/less/layout.less
+++ b/Resources/public/less/layout.less
@@ -75,6 +75,11 @@
     .lighttextshadow;
 }
 #footernavi {
+  .footernavi-inner {
+      @media (min-width: @screen-sm-min) {
+          float: right;
+      }
+  }
   .nav-list {
     padding-left: 0;
     li a {
@@ -181,7 +186,7 @@ padding: 20px 20px 0 20px;
         }
     }
     .nav>li>a {
-        padding-left: 0px;
+        padding: 3px 0;
     }
     .ga-optin-link, .ga-optout-link {
         cursor: pointer;

--- a/Resources/views/layoutTemplates/parts/footerStandard.inc.php
+++ b/Resources/views/layoutTemplates/parts/footerStandard.inc.php
@@ -102,8 +102,8 @@ $translator = ServiceLocator::get('translator');
     <div class="row" id="footerinfoline"><div class="col-xs-12 border">
         <div class="row">
             <div class="col-xs-12 col-sm-4 preiseinfo"><?= $translator->trans('chameleon_system_chameleon_shop_theme.layout.footer_price_note', array('%sShippingLink%' => TdbShop::GetInstance()->GetLinkToSystemPageAsPopUp($translator->trans('chameleon_system_chameleon_shop_theme.layout.footer_shipping'), 'shipping'))); ?></div>
-            <div class="col-xs-12 col-sm-4" id="footernavi"><div class=""><?php $modules->GetModule('footernavi'); ?></div></div>
-            <div class="col-xs-12 col-sm-4 ga-optout-optin-link" style="display: none">
+            <div class="col-xs-12 col-sm-8" id="footernavi"><div class="footernavi-inner"><?php $modules->GetModule('footernavi'); ?></div></div>
+            <div class="col-xs-12 ga-optout-optin-link" style="display: none">
                 <a class="ga-optout-link"><?= $translator->trans('chameleon_system_chameleon_shop_theme.google_analytics.opt_out'); ?></a>
                 <a class="ga-optin-link"><?= $translator->trans('chameleon_system_chameleon_shop_theme.google_analytics.opt_in'); ?></a>
             </div>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | 6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Fixed issues  | #7 
| License       | MIT

It was only a styling bug. On desktops the footer naviation broke into a new line.

