### PR TITLE
16 use image crop bundle in theme

### DIFF
--- a/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
+++ b/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
@@ -8,16 +8,25 @@ TCMSLogChange::requireBundleUpdates('ChameleonSystemImageCropBundle', 1534864767
 
 $databaseConnection = TCMSLogChange::getDatabaseConnection();
 $highestPosition = (int) $databaseConnection->fetchColumn('SELECT MAX(`position`) FROM `cms_image_crop_preset`');
+$newPresetId = TCMSLogChange::createUnusedRecordId('cms_image_crop_preset');
 
-$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'en')
     ->setFields(
         [
-            'name' => 'Standard-Teaser',
+            'name' => 'Default Teaser (used in product lists for example)',
             'width' => '324',
             'height' => '450',
             'system_name' => 'snippetTeaserStandardBase',
             'position' => $highestPosition++,
-            'id' => TCMSLogChange::createUnusedRecordId('cms_image_crop_preset'),
+            'id' => $newPresetId,
         ]
     );
 TCMSLogChange::insert(__LINE__, $data);
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+    ->setFields(
+        [
+            'name' => 'Standard-Teaser (z.B. in Produktlisten verwendet)',
+        ]
+    )->setWhereEquals(['id' => $newPresetId]);
+TCMSLogChange::update(__LINE__, $data);

--- a/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
+++ b/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
@@ -17,7 +17,7 @@ $data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
             'height' => '450',
             'system_name' => 'snippetTeaserStandardBase',
             'position' => $highestPosition++,
-            'id' => '240b9fd8-1546-bcca-73f1-20af946f249f',
+            'id' => TCMSLogChange::createUnusedRecordId('cms_image_crop_preset'),
         ]
     );
 TCMSLogChange::insert(__LINE__, $data);

--- a/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
+++ b/Bridge/Chameleon/Migration/Script/update-1546858291.inc.php
@@ -1,0 +1,23 @@
+<h1>Build #1546858291</h1>
+<h2>Date: 2019-01-07</h2>
+<div class="changelog">
+    - add image crop preset for default teaser
+</div>
+<?php
+TCMSLogChange::requireBundleUpdates('ChameleonSystemImageCropBundle', 1534864767);
+
+$databaseConnection = TCMSLogChange::getDatabaseConnection();
+$highestPosition = (int) $databaseConnection->fetchColumn('SELECT MAX(`position`) FROM `cms_image_crop_preset`');
+
+$data = TCMSLogChange::createMigrationQueryData('cms_image_crop_preset', 'de')
+    ->setFields(
+        [
+            'name' => 'Standard-Teaser',
+            'width' => '324',
+            'height' => '450',
+            'system_name' => 'snippetTeaserStandardBase',
+            'position' => $highestPosition++,
+            'id' => '240b9fd8-1546-bcca-73f1-20af946f249f',
+        ]
+    );
+TCMSLogChange::insert(__LINE__, $data);

--- a/Resources/views/snippets/common/teaser/standard-base.html.twig
+++ b/Resources/views/snippets/common/teaser/standard-base.html.twig
@@ -14,7 +14,12 @@
     <div class="content">
         <div class="image">
             {% block image -%}
-                <a href="{{ sLink }}"><img src="{{ sImageId | cmsthumb(iMaxImageWidth,iMaxImageHeight,true) }}" alt="{{ (sTopic~" "~sHeadline)|trim }}"/></a>
+                {% if sImageId|imageHasCropDataForPreset('snippetTeaserStandardBase') %}
+                    {% set imageUrl = sImageId|imageUrlWithCropFallbackPreset(null, 'snippetTeaserStandardBase') %}
+                {% else %}
+                    {% set imageUrl = sImageId|cmsthumb(iMaxImageWidth,iMaxImageHeight,true) %}
+                {% endif %}
+                <a href="{{ sLink }}"><img src="{{ imageUrl|e('html_attr') }}" alt="{{ (sTopic~" "~sHeadline)|trim }}"/></a>
             {%- endblock %}
         </div>
         <div class="body">

--- a/Resources/views/snippets/pkgImageHotspot/item.html.twig
+++ b/Resources/views/snippets/pkgImageHotspot/item.html.twig
@@ -17,6 +17,7 @@
             sLinkJS
             bIsActive
         sBackgroundImageId
+        backgroundImageCropId
         sBackgroundImageAlt
         aImageLayoverList
             iLeft
@@ -37,8 +38,12 @@
             imageMap
 #}
 
-
-<img class="backgroundImage" src="{{ sBackgroundImageId | cmsthumb(1170,385,true) }}" height="385" alt="{{ sBackgroundImageAlt }}" usemap="#image{{ sBackgroundImageId }}" />
+{% if backgroundImageCropId is not null %}
+    {% set backgroundImageUrl = sBackgroundImageId|imageUrlWithCropFallbackPreset(backgroundImageCropId, 'pkgImageHotspotItemBackground') %}
+{% else %}
+    {% set backgroundImageUrl = sBackgroundImageId | cmsthumb(1170,385,true) %}
+{% endif %}
+<img class="backgroundImage" src="{{ backgroundImageUrl|e('html_attr') }}" height="385" alt="{{ sBackgroundImageAlt }}" usemap="#image{{ sBackgroundImageId }}" />
 
 {# add image marker  #}
 {% if aImageLayoverList is defined and aImageLayoverList|length > 0 %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        |  master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed issues  | #16
| License       | MIT

Use image crops for image hotspot and base teaser.

ATTENTION: This PR requires the ImageCropBundle to be integrated in chameleon-base and https://github.com/chameleon-system/chameleon-shop/pull/35 to be merged.