### PR TITLE
ref #296: reload page on clicking back button (ios safari loads page …

### DIFF
--- a/Resources/public/js/chameleon.js
+++ b/Resources/public/js/chameleon.js
@@ -7,6 +7,14 @@ CHAMELEON.Custom.GetLoadingImageConfig = function () {
     return {baseZ:2000, bindEvents:false, constrainTabKey:false, timeout:50000, css:{border:'none', backgroundColor:'transparent'}, overlayCSS:{backgroundColor:'#fff', opacity:0.5}, message:'<div class="loadingbg"><img src="/assets/images/loader.gif" /></div>' };
 };
 
+window.onpageshow = function(event) {
+    if (event.persisted) {
+        window.location.reload();
+    }
+};
+
+$(window).on('unload', function () { });
+
 function GetAjaxCall(url, functionName) {
     $.ajax({
         url:url,


### PR DESCRIPTION
…from cache on clicking back button.Then some button loose their functionality)

| Q             | A
| ------------- | ---
| Branch        |  6.2.x
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no 
| Deprecations? | no
| Tests pass?   | yes 
| Fixed issues  | chameleon-system/chameleon-system#296
| License       | MIT

