### PR TITLE
ref #31: shop menu button moved to fixed header

### DIFF
--- a/Resources/public/less/layout.less
+++ b/Resources/public/less/layout.less
@@ -289,12 +289,8 @@ a.cmsanchor:before {
 @media (max-width: @screen-xs-max) {
     .mainnav-search-container {
         position: relative;
-        margin-top: 85px;
+        margin-top: 110px;
         #minisearch {
-            position: absolute;
-            top: 0;
-            z-index: 5;
-            width: 75%;
             .snippetModulesMTShopSearchFormQuicksearch {
                 border: 1px solid @cmsBorder7;
                 margin: 0;

--- a/Resources/public/snippets/common/navigation/navigationMobile.js
+++ b/Resources/public/snippets/common/navigation/navigationMobile.js
@@ -5,8 +5,15 @@ $(document).ready(function(){
 
     $(".searchMagnifier").on('click', function() {
         $('html, body').animate({
-            scrollTop: $("#quicksearchform").offset().top -100
-        }, 1000);
+            scrollTop: $("#minisearch").offset().top -100
+        }, 500);
         $("#quicksearchform input[name=q]").focus();
     });
+
+    $("#buttonMobileNavigationMain").click(function() {
+        $('html, body').animate({
+            scrollTop: $("#mainnav").offset().top -150
+        }, 500);
+    });
+
 });

--- a/Resources/public/snippets/common/navigation/navigationTop.less
+++ b/Resources/public/snippets/common/navigation/navigationTop.less
@@ -43,10 +43,15 @@
         align-items: center;
         color: @cmsColorPrimaryHigh1;
         font-size: @cmsFontBaseSize+10;
-        margin-left: 1em;
+        margin-left: 0;
 
         .searchMagnifier {
           font-size: 0.8em;
+          margin-top: 5px;
+          display: none;
+          @media (min-width: 400px) {
+            display: block;
+          }
         }
 
         a {
@@ -55,19 +60,21 @@
 
         .miniBasketMobile {
           margin-left: 0.5em;
-          margin-right: 0.1em;
-          @media (min-width: 580px) {
-            margin-left: 1em;
-            margin-right: 0.5em;
-          }
+          margin-right: 0.5em;
+          margin-top: 5px;
+          padding-left: 0;
 
           position: relative;
           .amount {
             position: absolute;
-            top: 5px;
-            right: -5px;
+            top: -5px;
+            right: 3px;
             background: @cmsBackground6;
           }
+        }
+
+        #mainMenueButton .navbar-toggle {
+          margin-right: 0;
         }
       }
     }

--- a/Resources/views/layoutTemplates/parts/headerStandard.inc.php
+++ b/Resources/views/layoutTemplates/parts/headerStandard.inc.php
@@ -28,6 +28,20 @@ $translator = ServiceLocator::get('translator');
                         <div class="navbar-brand-icons">
                             <div class="searchMagnifier"><span class="glyphicon glyphicon-search"></span></div>
                             <div class="miniBasketMobile"><?php $modules->GetModule('minibasketmobile'); ?></div>
+                            <div id="mainMenueButton">
+                                <button class="navbar-toggle collapsed" id="buttonMobileNavigationMain" data-toggle="collapse"
+                                        data-target="#mainMenu" aria-expanded="false">
+                                    <span class="sr-only"><?= $translator->trans('chameleon_system_chameleon_shop_theme.navigation.shop_menu'); ?></span>
+                                    <span class="icon-menu">
+                                        <span class="icon-bar"></span>
+                                        <span class="icon-bar"></span>
+                                        <span class="icon-bar"></span>
+                                    </span>
+                                    <span class="buttonText">
+                                        <?= $translator->trans('chameleon_system_chameleon_shop_theme.navigation.shop_menu'); ?>
+                                    </span>
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/Resources/views/snippets/common/navigation/navigationMain.html.twig
+++ b/Resources/views/snippets/common/navigation/navigationMain.html.twig
@@ -24,20 +24,7 @@
 {% if iLevel == 1 %}
     <nav class="hidden-print">
         <div class="navbar navbar-default">
-            <div class="navbar-header">
-                <button class="navbar-toggle collapsed" id="buttonMobileNavigationMain" data-toggle="collapse"
-                        data-target="#mainMenu" aria-expanded="false">
-                    <span class="sr-only">{{ "chameleon_system_chameleon_shop_theme.navigation.shop_menu"|trans }}</span>
-                    <span class="icon-menu">
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </span>
-                    <span class="buttonText">
-                        {{ "chameleon_system_chameleon_shop_theme.navigation.shop_menu"|trans }}
-                    </span>
-                </button>
-            </div>
+            {# the mobile menu-button (navbar-header) has moved to headerStandard.inc.php within the fixed header #}
 
             <div id="mainMenu" class="collapse navbar-collapse">
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | features / 6.3.x 
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed issues  | #31 
| License       | MIT

Frontend: The main navigation button, previously to the right of the search field, is now in the fixed header area next to the service menu button.
The main navigation itself is unchanged next to the search field.