### PR TITLE
ref #29: styling retailer price on small mobiles

### DIFF
--- a/Resources/public/snippets/pkgShop/shopArticle/articlePrice.less
+++ b/Resources/public/snippets/pkgShop/shopArticle/articlePrice.less
@@ -1,4 +1,7 @@
 .snippetShopArticleArticlePrice {
+    position: relative;
+    display: inline-block;
+    width: 100%;
     .snippetShopArticlePrice {
         font-size: 17px;
         .currency {
@@ -15,6 +18,13 @@
 
     .retailPrice {
         padding-left: 5px;
+
+        @media screen and (max-width: 450px) {
+            position: absolute;
+            left: 0;
+            top: -12px;
+            padding-left: 0;
+        }
 
         .snippetShopArticlePrice {
             .cmsHeadlineSmall();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        |  6.3.x for bug fixes
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | #29...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Product Lists:
On small mobile devices (width lower than 450px) the valid price and the crossed-out price don't fit into one line. In this case the crossed-out price is placed (absolute) above the valid price into an empty line.
Thus a line break is prevented and the article boxes always keep the same height.

![Selection_405](https://user-images.githubusercontent.com/26296728/66302256-e1d6e080-e8f8-11e9-9d41-744b8fb5a911.jpg)

