### PR TITLE
ref #29: product list: new/sale-buttons in one line in every browser

### DIFF
--- a/Resources/public/snippets/common/teaser/standard-shopArticle.less
+++ b/Resources/public/snippets/common/teaser/standard-shopArticle.less
@@ -76,6 +76,7 @@
 
 .snippetTeaserStandardBase .infoline .icons ul {
   margin: 0;
+  padding-left: 0;
   list-style: none;
   float: right;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        |  6.3.x for bug fixes <!-- see below -->
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | #29...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Product-List:
In some mobile browsers, the "Sales" and "New" buttons are displayed in 2 lines. However, they should always be displayed next to each other. Some browsers set a padding-inline-start of 40px to the ul-element.  This leads to the line break.
To overwrite this, the ul-element in the infoline needs a padding-left: 0;

