### PR TITLE
Use basketUrl post render variable

### DIFF
--- a/Resources/views/snippets/pkgShop/shopBasket/shopBasketMiniBasket.html.twig
+++ b/Resources/views/snippets/pkgShop/shopBasket/shopBasketMiniBasket.html.twig
@@ -24,7 +24,7 @@
     <div class="shopBasketMiniBasketBox">
         <div class="shopBasketMiniBasketBoxBoxInner">
             <div class="shopBasketMiniBasketBoxBoxSpacerRight">
-                <a class="shopBasketMiniBasketBoxBoxSpacerLeft teaser" href="{{sBasketURL|raw}}" title="{{"chameleon_system_chameleon_shop_theme.minibasket.action_show_basket_title"|trans}}">
+                <a class="shopBasketMiniBasketBoxBoxSpacerLeft teaser" href="[{basketUrl}]" title="{{"chameleon_system_chameleon_shop_theme.minibasket.action_show_basket_title"|trans}}">
                     <span class="leftBasketIcon">
                         <span class="i i-basket_icon">&nbsp;</span>
                     </span>

--- a/Resources/views/snippets/pkgShop/shopBasket/shopBasketMiniBasketMobile.html.twig
+++ b/Resources/views/snippets/pkgShop/shopBasket/shopBasketMiniBasketMobile.html.twig
@@ -20,7 +20,7 @@
         ** sArticleDetailURL
 #}
 
-<a class="basketIconMobile" href="{{sBasketURL|raw}}" title="{{"chameleon_system_chameleon_shop_theme.minibasket.action_show_basket_title"|trans}}">
+<a class="basketIconMobile" href="[{basketUrl}]" title="{{"chameleon_system_chameleon_shop_theme.minibasket.action_show_basket_title"|trans}}">
     <span class="glyphicon glyphicon-shopping-cart">&nbsp;</span>
     <span class="amount badge">{{ sNumberOfProducts }}</span>
 </a>


### PR DESCRIPTION
Together chameleon-system/chameleon-shop#92 this fixes chameleon-system/chameleon-system#654


| Q             | A
| ------------- | ---
| Branch        | 6.3.x
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Fixed issues  | chameleon-system/chameleon-system#654   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

Uses the post render variables introduced with chameleon-system/chameleon-shop#92 in order to prevent
incorrect caching of the basket URL.

Note: chameleon-system/chameleon-shop#92 should be merged before merging this PR.
