### PR TITLE
ref #668: Update phpunit to be PHP8 compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: php
 sudo: false
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
+  - '8.0'
   - nightly
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "chameleon-system/code-style-config": "dev-master@dev",
         "chameleon-system/sanitycheck": "~7.1.0",
         "chameleon-system/sanitycheck-bundle": "~7.1.0",
-        "phpunit/phpunit": "~7.0"
+        "phpunit/phpunit": "^8.5.13"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch        | master
| Bug fix?      | no
| New feature?  | no <!-- don't forget to update CHANGELOG.md files -->
| BC breaks?    | no     <!-- does the change break backwards compatibility? Only allowed for major versions -->
| Deprecations? | no <!-- don't forget to update UPGRADE-*.md and CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed issues  | chameleon-system/chameleon-system#668   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

In an effort to update core components to PHP8 this updates phpunit to 8.x. This makes the tests runnable in PHP8 but drops support for running tests in PHP7.1.
